### PR TITLE
Added Collection class & improved FileBuilder

### DIFF
--- a/src/cpp/FileBuilder.cpp
+++ b/src/cpp/FileBuilder.cpp
@@ -36,7 +36,7 @@
 	 file << note.title() << "\n";
  }
  void FileBuilder::writeCreationTime(std::ofstream& file, TextNote note) {
- 	 file << note.creation_time() << "\n";
+ 	 file << toDateFormat(note.creation_time()) << "\n";
  }
  void FileBuilder::writeText(std::ofstream& file, TextNote note) {
 	 file << note.text();
@@ -69,12 +69,11 @@ std::string FileBuilder::readTitle(std::ifstream& file) {
 	return title;
 }
 std::time_t FileBuilder::readCreationTime(std::ifstream& file) {
-	const int charsInDate = 12;
-	std::time_t time;
-	char date[charsInDate];
+	std::string line;
 
-	file.getline(date, charsInDate);
-	time = std::atoi(date);
+	std::getline(file, line);
+	std::time_t time = fromDateFormat(line);
+	assert (time != -1); //is valid
 	return time;
 }
 
@@ -90,3 +89,24 @@ std::string FileBuilder::readText(std::ifstream& file) {
 	}
 	return noteText;
 }
+
+
+std::string FileBuilder::toDateFormat(std::time_t time) {
+	const unsigned int maxChar = 40;
+	char date[maxChar];
+	std::strftime(date, sizeof(date), "%Y.%m.%d %H:%M:%S", std::localtime(&time));
+	return std::string(date);
+}
+
+std::time_t FileBuilder::fromDateFormat(std::string str) {
+	struct std::tm tm;
+	std::sscanf(str.c_str(), "%d.%d.%d %d:%d:%d", &tm.tm_year,
+			&tm.tm_mon, &tm.tm_mday, &tm.tm_hour, &tm.tm_min, &tm.tm_sec);
+
+	tm.tm_year -= 1900; //1900 -> 0, 2022 -> 122
+	tm.tm_mon -= 1; //January = 0
+	int a = 0;
+	a++;
+	return std::mktime(&tm);
+}
+

--- a/src/cpp/FileBuilder.cpp
+++ b/src/cpp/FileBuilder.cpp
@@ -13,8 +13,8 @@
 }
 
  void FileBuilder::writeNote(std::ofstream& file, TextNote* note) {
-	 writeTitle(file, note->title());
 	 writeCreationTime(file, note->creation_time());
+	 writeTitle(file, note->title());
 	 writeText(file, note);
  }
 
@@ -53,8 +53,8 @@ std::ifstream FileBuilder::openFile(std::string filename) {
 }
 
 TextNote FileBuilder::initTextNote(std::ifstream& file) {
-	std::string title = readTitle(file);
 	std::time_t creationTime = readCreationTime(file);
+	std::string title = readTitle(file);
 	std::string text = readText(file);
 
 	return TextNote(title, text, creationTime);
@@ -108,8 +108,8 @@ std::time_t FileBuilder::fromDateFormat(std::string str) {
 
 bool FileBuilder::toFile(TextNoteCollection* collection, std::string path) {
 	std::ofstream file = createFile(collection->title(), path);
-	writeTitle(file, collection->title());
 	writeCreationTime(file, collection->creation_time());
+	writeTitle(file, collection->title());
 	writeCollectionNotes(file, collection);
 	return false;
 }
@@ -123,8 +123,8 @@ void FileBuilder::writeCollectionNotes(std::ofstream& file, TextNoteCollection* 
 TextNoteCollection FileBuilder::collectionFromFile(std::string filename) {
 	std::ifstream file = openFile(filename);
 
-	std::string title = readTitle(file);
 	std::time_t creationTime = readCreationTime(file);
+	std::string title = readTitle(file);
 	TextNoteCollection collection = TextNoteCollection(title, creationTime);
 	readCollectionNotes(file, collection);
 	return collection;

--- a/src/cpp/FileBuilder.cpp
+++ b/src/cpp/FileBuilder.cpp
@@ -1,0 +1,93 @@
+#include "FileBuilder.h"
+#include <cassert>
+ bool FileBuilder::toFile(TextNote note, std::string path) {
+	 std::ofstream file = createFile(note, path);
+	 if (file.fail())
+		 return true;
+
+	 writeFile(file, note);
+	 file.close();
+
+	 return false;
+
+}
+
+ void FileBuilder::writeFile(std::ofstream& file, TextNote note) {
+	 writeTitle(file, note);
+	 writeCreationTime(file, note);
+	 writeText(file, note);
+ }
+
+
+
+
+ std::ofstream FileBuilder::createFile(TextNote note, std::string path) {
+	 std::ofstream file;
+	 file.open(getFileName(note, path));
+	 return file;
+ }
+ std::string FileBuilder::getFileName(TextNote note,std::string path) {
+	 return note.title() + "." +
+			 TEXT_FILE_EXTENSION;
+ }
+
+
+ void FileBuilder::writeTitle(std::ofstream& file, TextNote note) {
+	 file << note.title() << "\n";
+ }
+ void FileBuilder::writeCreationTime(std::ofstream& file, TextNote note) {
+ 	 file << note.creation_time() << "\n";
+ }
+ void FileBuilder::writeText(std::ofstream& file, TextNote note) {
+	 file << note.text();
+ }
+
+TextNote FileBuilder::fromFile(std::string filename){
+	 std::ifstream file = openFile(filename);
+	 TextNote note = initTextNote(file);
+	 file.close();
+	 return note;
+ }
+
+std::ifstream FileBuilder::openFile(std::string filename) {
+	std::ifstream file;
+	file.open(filename);
+	assert (!file.fail()); //file exists
+	return file;
+}
+
+TextNote FileBuilder::initTextNote(std::ifstream& file) {
+	std::string title = readTitle(file);
+	std::time_t creationTime = readCreationTime(file);
+	std::string text = readText(file);
+
+	return TextNote(title, text, creationTime);
+}
+std::string FileBuilder::readTitle(std::ifstream& file) {
+	std::string title;
+	std::getline(file, title);
+	return title;
+}
+std::time_t FileBuilder::readCreationTime(std::ifstream& file) {
+	const int charsInDate = 12;
+	std::time_t time;
+	char date[charsInDate];
+
+	file.getline(date, charsInDate);
+	time = std::atoi(date);
+	return time;
+}
+
+std::string FileBuilder::readText(std::ifstream& file) {
+	std::string line;
+	std::string noteText;
+
+	while (std::getline(file, line)) {
+		noteText += line;
+		if (!file.eof()) {
+			noteText += "\n";
+		}
+	}
+	file.clear();
+	return noteText;
+}

--- a/src/cpp/FileBuilder.cpp
+++ b/src/cpp/FileBuilder.cpp
@@ -29,13 +29,13 @@
 
 
  void FileBuilder::writeTitle(std::ofstream& file, std::string title) {
-	 file <<title << "\n";
+	 file << title << "\n";
  }
  void FileBuilder::writeCreationTime(std::ofstream& file, std::time_t creation_time) {
  	 file << toDateFormat(creation_time) << "\n";
  }
  void FileBuilder::writeText(std::ofstream& file, TextNote* note) {
-	 file << note->text() << END_CHAR;
+	 file << note->text() << END_CHAR << "\n";
  }
 
 TextNote FileBuilder::fromFile(std::string filename){
@@ -47,7 +47,7 @@ TextNote FileBuilder::fromFile(std::string filename){
 
 std::ifstream FileBuilder::openFile(std::string filename) {
 	std::ifstream file;
-	file.open(filename);
+	file.open(getFileName(filename));
 	assert (!file.fail()); //file exists
 	return file;
 }
@@ -108,7 +108,7 @@ std::time_t FileBuilder::fromDateFormat(std::string str) {
 }
 
 
-bool FileBuilder::collectionToFile(TextNoteCollection* collection, std::string path) {
+bool FileBuilder::toFile(TextNoteCollection* collection, std::string path) {
 	std::ofstream file = createFile(collection->title(), path);
 	writeTitle(file, collection->title());
 	writeCreationTime(file, collection->creation_time());
@@ -120,6 +120,21 @@ void FileBuilder::writeCollectionNotes(std::ofstream& file, TextNoteCollection* 
 	for (std::size_t i = 0; i < collection->size(); i++) {
 		TextNote note = collection->getNote(i);
 		writeNote(file, &note);
+	}
+}
+TextNoteCollection FileBuilder::collectionFromFile(std::string filename) {
+	std::ifstream file = openFile(filename);
+
+	std::string title = readTitle(file);
+	std::time_t creationTime = readCreationTime(file);
+	TextNoteCollection collection = TextNoteCollection(title, creationTime);
+	readCollectionNotes(file, collection);
+	return collection;
+}
+
+void FileBuilder::readCollectionNotes(std::ifstream& file, TextNoteCollection& collection) {
+	while (file.peek() != EOF) {
+		collection.add(initTextNote(file));
 	}
 }
 

--- a/src/cpp/FileBuilder.cpp
+++ b/src/cpp/FileBuilder.cpp
@@ -88,6 +88,5 @@ std::string FileBuilder::readText(std::ifstream& file) {
 			noteText += "\n";
 		}
 	}
-	file.clear();
 	return noteText;
 }

--- a/src/cpp/FileBuilder.cpp
+++ b/src/cpp/FileBuilder.cpp
@@ -102,8 +102,6 @@ std::time_t FileBuilder::fromDateFormat(std::string str) {
 
 	tm.tm_year -= 1900; //1900 -> 0, 2022 -> 122
 	tm.tm_mon -= 1; //January = 0
-	int a = 0;
-	a++;
 	return std::mktime(&tm);
 }
 

--- a/src/cpp/FileBuilder.cpp
+++ b/src/cpp/FileBuilder.cpp
@@ -1,7 +1,7 @@
 #include "FileBuilder.h"
 #include <cassert>
- bool FileBuilder::toFile(TextNote note, std::string path) {
-	 std::ofstream file = createFile(note.title(), path);
+ bool FileBuilder::toFile(TextNote* note, std::string path) {
+	 std::ofstream file = createFile(note->title(), path);
 	 if (file.fail())
 		 return true;
 
@@ -12,9 +12,9 @@
 
 }
 
- void FileBuilder::writeNote(std::ofstream& file, TextNote note) {
-	 writeTitle(file, note.title());
-	 writeCreationTime(file, note.creation_time());
+ void FileBuilder::writeNote(std::ofstream& file, TextNote* note) {
+	 writeTitle(file, note->title());
+	 writeCreationTime(file, note->creation_time());
 	 writeText(file, note);
  }
 
@@ -34,8 +34,8 @@
  void FileBuilder::writeCreationTime(std::ofstream& file, std::time_t creation_time) {
  	 file << toDateFormat(creation_time) << "\n";
  }
- void FileBuilder::writeNote(std::ofstream& file, TextNote note) {
-	 file << note.text();
+ void FileBuilder::writeText(std::ofstream& file, TextNote* note) {
+	 file << note->text() << END_CHAR;
  }
 
 TextNote FileBuilder::fromFile(std::string filename){
@@ -79,9 +79,11 @@ std::string FileBuilder::readText(std::ifstream& file) {
 
 	while (std::getline(file, line)) {
 		noteText += line;
-		if (!file.eof()) {
-			noteText += "\n";
+		if (line.find(END_CHAR) != std::string::npos) {
+			noteText.pop_back();
+			break;
 		}
+		noteText += "\n";
 	}
 	return noteText;
 }
@@ -106,17 +108,18 @@ std::time_t FileBuilder::fromDateFormat(std::string str) {
 }
 
 
-bool FileBuilder::collectionToFile(TextNoteCollection collection, std::string path) {
-	std::ofstream file = createFile(collection.title(), path);
-	writeTitle(file, collection.title());
-	writeCreationTime(file, collection.creation_time());
+bool FileBuilder::collectionToFile(TextNoteCollection* collection, std::string path) {
+	std::ofstream file = createFile(collection->title(), path);
+	writeTitle(file, collection->title());
+	writeCreationTime(file, collection->creation_time());
 	writeCollectionNotes(file, collection);
 	return false;
 }
 
-void FileBuilder::writeCollectionNotes(std::ofstream& file, TextNoteCollection collection) {
+void FileBuilder::writeCollectionNotes(std::ofstream& file, TextNoteCollection* collection) {
 	for (std::size_t i = 0; i < collection.size(); i++) {
-		writeNote(file, collection.getNote(i));
+		TextNote note = collection.getNote(i);
+		writeNote(file, &note);
 	}
 }
 

--- a/src/cpp/FileBuilder.cpp
+++ b/src/cpp/FileBuilder.cpp
@@ -1,16 +1,20 @@
 #include "FileBuilder.h"
 #include <cassert>
- bool FileBuilder::toFile(TextNote* note, std::string path) {
+
+
+ void FileBuilder::toFile(TextNote* note, std::string path) {
 	 std::ofstream file = createFile(note->title(), path);
-	 if (file.fail())
-		 return true;
 
 	 writeNote(file, note);
 	 file.close();
 
-	 return false;
-
 }
+ std::ofstream FileBuilder::createFile(std::string name, std::string path) {
+	 std::ofstream file;
+	 file.open(getFileName(name, path));
+	 assert (!file.fail());
+	 return file;
+ }
 
  void FileBuilder::writeNote(std::ofstream& file, TextNote* note) {
 	 writeCreationTime(file, note->creation_time());
@@ -18,11 +22,7 @@
 	 writeText(file, note);
  }
 
- std::ofstream FileBuilder::createFile(std::string name, std::string path) {
-	 std::ofstream file;
-	 file.open(getFileName(name, path));
-	 return file;
- }
+
  std::string FileBuilder::getFileName(std::string name, std::string path) {
 	 return path + name + "." + TEXT_FILE_EXTENSION;
  }
@@ -48,7 +48,7 @@ TextNote FileBuilder::fromFile(std::string filename){
 std::ifstream FileBuilder::openFile(std::string filename) {
 	std::ifstream file;
 	file.open(getFileName(filename));
-	assert (!file.fail()); //file exists
+	assert (!file.fail());
 	return file;
 }
 
@@ -69,7 +69,7 @@ std::time_t FileBuilder::readCreationTime(std::ifstream& file) {
 
 	std::getline(file, line);
 	std::time_t time = fromDateFormat(line);
-	assert (time != -1); //is valid
+	assert (time != -1);
 	return time;
 }
 
@@ -79,7 +79,7 @@ std::string FileBuilder::readText(std::ifstream& file) {
 
 	while (std::getline(file, line)) {
 		noteText += line;
-		if (line.find(END_CHAR) != std::string::npos) {
+		if (containsEndChar(line)) {
 			noteText.pop_back();
 			break;
 		}
@@ -88,8 +88,12 @@ std::string FileBuilder::readText(std::ifstream& file) {
 	return noteText;
 }
 
+bool FileBuilder::containsEndChar(std::string line){
+	return line.find(END_CHAR) != std::string::npos;
+}
+
 std::string FileBuilder::toDateFormat(std::time_t time) {
-	const unsigned int maxChar = 40;
+	const unsigned int maxChar = 20;
 	char date[maxChar];
 	std::strftime(date, sizeof(date), "%Y.%m.%d %H:%M:%S", std::localtime(&time));
 	return std::string(date);
@@ -106,17 +110,16 @@ std::time_t FileBuilder::fromDateFormat(std::string str) {
 }
 
 
-bool FileBuilder::toFile(TextNoteCollection* collection, std::string path) {
+void FileBuilder::toFile(TextNoteCollection* collection, std::string path) {
 	std::ofstream file = createFile(collection->title(), path);
 	writeCreationTime(file, collection->creation_time());
 	writeTitle(file, collection->title());
 	writeCollectionNotes(file, collection);
-	return false;
 }
 
 void FileBuilder::writeCollectionNotes(std::ofstream& file, TextNoteCollection* collection) {
 	for (std::size_t i = 0; i < collection->size(); i++) {
-		TextNote note = collection->getNote(i);
+		TextNote note = collection->get(i);
 		writeNote(file, &note);
 	}
 }

--- a/src/cpp/FileBuilder.cpp
+++ b/src/cpp/FileBuilder.cpp
@@ -1,44 +1,40 @@
 #include "FileBuilder.h"
 #include <cassert>
  bool FileBuilder::toFile(TextNote note, std::string path) {
-	 std::ofstream file = createFile(note, path);
+	 std::ofstream file = createFile(note.title(), path);
 	 if (file.fail())
 		 return true;
 
-	 writeFile(file, note);
+	 writeNote(file, note);
 	 file.close();
 
 	 return false;
 
 }
 
- void FileBuilder::writeFile(std::ofstream& file, TextNote note) {
-	 writeTitle(file, note);
-	 writeCreationTime(file, note);
+ void FileBuilder::writeNote(std::ofstream& file, TextNote note) {
+	 writeTitle(file, note.title());
+	 writeCreationTime(file, note.creation_time());
 	 writeText(file, note);
  }
 
-
-
-
- std::ofstream FileBuilder::createFile(TextNote note, std::string path) {
+ std::ofstream FileBuilder::createFile(std::string name, std::string path) {
 	 std::ofstream file;
-	 file.open(getFileName(note, path));
+	 file.open(getFileName(name, path));
 	 return file;
  }
- std::string FileBuilder::getFileName(TextNote note,std::string path) {
-	 return note.title() + "." +
-			 TEXT_FILE_EXTENSION;
+ std::string FileBuilder::getFileName(std::string name, std::string path) {
+	 return path + name + "." + TEXT_FILE_EXTENSION;
  }
 
 
- void FileBuilder::writeTitle(std::ofstream& file, TextNote note) {
-	 file << note.title() << "\n";
+ void FileBuilder::writeTitle(std::ofstream& file, std::string title) {
+	 file <<title << "\n";
  }
- void FileBuilder::writeCreationTime(std::ofstream& file, TextNote note) {
- 	 file << toDateFormat(note.creation_time()) << "\n";
+ void FileBuilder::writeCreationTime(std::ofstream& file, std::time_t creation_time) {
+ 	 file << toDateFormat(creation_time) << "\n";
  }
- void FileBuilder::writeText(std::ofstream& file, TextNote note) {
+ void FileBuilder::writeNote(std::ofstream& file, TextNote note) {
 	 file << note.text();
  }
 
@@ -90,7 +86,6 @@ std::string FileBuilder::readText(std::ifstream& file) {
 	return noteText;
 }
 
-
 std::string FileBuilder::toDateFormat(std::time_t time) {
 	const unsigned int maxChar = 40;
 	char date[maxChar];
@@ -108,5 +103,20 @@ std::time_t FileBuilder::fromDateFormat(std::string str) {
 	int a = 0;
 	a++;
 	return std::mktime(&tm);
+}
+
+
+bool FileBuilder::collectionToFile(TextNoteCollection collection, std::string path) {
+	std::ofstream file = createFile(collection.title(), path);
+	writeTitle(file, collection.title());
+	writeCreationTime(file, collection.creation_time());
+	writeCollectionNotes(file, collection);
+	return false;
+}
+
+void FileBuilder::writeCollectionNotes(std::ofstream& file, TextNoteCollection collection) {
+	for (std::size_t i = 0; i < collection.size(); i++) {
+		writeNote(file, collection.getNote(i));
+	}
 }
 

--- a/src/cpp/FileBuilder.cpp
+++ b/src/cpp/FileBuilder.cpp
@@ -117,8 +117,8 @@ bool FileBuilder::collectionToFile(TextNoteCollection* collection, std::string p
 }
 
 void FileBuilder::writeCollectionNotes(std::ofstream& file, TextNoteCollection* collection) {
-	for (std::size_t i = 0; i < collection.size(); i++) {
-		TextNote note = collection.getNote(i);
+	for (std::size_t i = 0; i < collection->size(); i++) {
+		TextNote note = collection->getNote(i);
 		writeNote(file, &note);
 	}
 }

--- a/src/cpp/FileBuilder.h
+++ b/src/cpp/FileBuilder.h
@@ -33,8 +33,8 @@ public:
 private:
 	static constexpr const char* TEXT_FILE_EXTENSION = "txt";
 	static constexpr char END_CHAR = -3;
-	static std::ofstream createFile(std::string name, std::string path);
 
+	static std::ofstream createFile(std::string name, std::string path);
 	static void writeNote(std::ofstream& file, TextNote* note);
 	static void writeTitle(std::ofstream& file, std::string title);
 	static void writeCreationTime(std::ofstream& file, std::time_t creation_time);

--- a/src/cpp/FileBuilder.h
+++ b/src/cpp/FileBuilder.h
@@ -23,22 +23,22 @@
 
 class FileBuilder {
 public:
-	static bool toFile(TextNote note, std::string path = "");
+	static bool toFile(TextNote* note, std::string path = "");
 	static TextNote fromFile(std::string filename);
-	static bool collectionToFile(TextNoteCollection collection, std::string path = "");
+	static bool collectionToFile(TextNoteCollection* collection, std::string path = "");
 
 	static std::string toDateFormat(std::time_t time);
 	static std::time_t fromDateFormat(std::string str);
 	static std::string getFileName(std::string name, std::string path = "");
 private:
 	static constexpr const char* TEXT_FILE_EXTENSION = "txt";
-
+	static constexpr char END_CHAR = -3;
 	static std::ofstream createFile(std::string name, std::string path);
 
-	static void writeNote(std::ofstream& file, TextNote note);
+	static void writeNote(std::ofstream& file, TextNote* note);
 	static void writeTitle(std::ofstream& file, std::string title);
 	static void writeCreationTime(std::ofstream& file, std::time_t creation_time);
-	static void writeText(std::ofstream& file, TextNote note);
+	static void writeText(std::ofstream& file, TextNote* note);
 
 	static std::ifstream openFile(std::string path);
 	static TextNote initTextNote(std::ifstream& file);
@@ -46,7 +46,7 @@ private:
 	static std::time_t readCreationTime(std::ifstream& file);
 	static std::string readText(std::ifstream& file);
 	static int countBrackets(std::string str);
-	static void writeCollectionNotes(std::ofstream& file, TextNoteCollection collection);
+	static void writeCollectionNotes(std::ofstream& file, TextNoteCollection* collection);
 
 
 

--- a/src/cpp/FileBuilder.h
+++ b/src/cpp/FileBuilder.h
@@ -25,8 +25,8 @@ class FileBuilder {
 public:
 	static bool toFile(TextNote* note, std::string path = "");
 	static TextNote fromFile(std::string filename);
-	static bool collectionToFile(TextNoteCollection* collection, std::string path = "");
-
+	static bool toFile(TextNoteCollection* collection, std::string path = "");
+	static TextNoteCollection collectionFromFile(std::string filename);
 	static std::string toDateFormat(std::time_t time);
 	static std::time_t fromDateFormat(std::string str);
 	static std::string getFileName(std::string name, std::string path = "");
@@ -47,6 +47,7 @@ private:
 	static std::string readText(std::ifstream& file);
 	static int countBrackets(std::string str);
 	static void writeCollectionNotes(std::ofstream& file, TextNoteCollection* collection);
+	static void readCollectionNotes(std::ifstream& file, TextNoteCollection& collection);
 
 
 

--- a/src/cpp/FileBuilder.h
+++ b/src/cpp/FileBuilder.h
@@ -1,7 +1,7 @@
 /*
  * FileBuilder.h
  *
- *  Created on:  9 Sep. 2022 р.
+ *  Created on:  9 Sep. 2022
  *      Author: MouseCreateor
  */
 
@@ -11,6 +11,7 @@
 #include <fstream>
 
 #include "TextNote.h"
+#include "TextNoteCollection.h"
 #include <ctime>
 
 /*
@@ -23,15 +24,20 @@
 class FileBuilder {
 public:
 	static bool toFile(TextNote note, std::string path = "");
-	static std::string getFileName(TextNote note, std::string path = "");
 	static TextNote fromFile(std::string filename);
+	static bool collectionToFile(TextNoteCollection collection, std::string path = "");
+
+	static std::string toDateFormat(std::time_t time);
+	static std::time_t fromDateFormat(std::string str);
+	static std::string getFileName(std::string name, std::string path = "");
 private:
 	static constexpr const char* TEXT_FILE_EXTENSION = "txt";
 
-	static std::ofstream createFile(TextNote note, std::string path);
-	static void writeFile(std::ofstream& file, TextNote note);
-	static void writeTitle(std::ofstream& file, TextNote note);
-	static void writeCreationTime(std::ofstream& file, TextNote note);
+	static std::ofstream createFile(std::string name, std::string path);
+
+	static void writeNote(std::ofstream& file, TextNote note);
+	static void writeTitle(std::ofstream& file, std::string title);
+	static void writeCreationTime(std::ofstream& file, std::time_t creation_time);
 	static void writeText(std::ofstream& file, TextNote note);
 
 	static std::ifstream openFile(std::string path);
@@ -39,9 +45,8 @@ private:
 	static std::string readTitle(std::ifstream& file);
 	static std::time_t readCreationTime(std::ifstream& file);
 	static std::string readText(std::ifstream& file);
-
-	static std::string toDateFormat(std::time_t time);
-	static std::time_t fromDateFormat(std::string str);
+	static int countBrackets(std::string str);
+	static void writeCollectionNotes(std::ofstream& file, TextNoteCollection collection);
 
 
 

--- a/src/cpp/FileBuilder.h
+++ b/src/cpp/FileBuilder.h
@@ -40,6 +40,9 @@ private:
 	static std::time_t readCreationTime(std::ifstream& file);
 	static std::string readText(std::ifstream& file);
 
+	static std::string toDateFormat(std::time_t time);
+	static std::time_t fromDateFormat(std::string str);
+
 
 
 

--- a/src/cpp/FileBuilder.h
+++ b/src/cpp/FileBuilder.h
@@ -1,0 +1,51 @@
+/*
+ * FileBuilder.h
+ *
+ *  Created on:  9 Sep. 2022 р.
+ *      Author: MouseCreateor
+ */
+
+#ifndef FILEBUILDER_H_
+#define FILEBUILDER_H_
+
+#include <fstream>
+
+#include "TextNote.h"
+#include <ctime>
+
+/*
+ * File format is the following:
+ * line 0: title
+ * line 1: creation time (as time_t)
+ * the rest is the text message of the note
+ */
+
+class FileBuilder {
+public:
+	static bool toFile(TextNote note, std::string path = "");
+	static std::string getFileName(TextNote note, std::string path = "");
+	static TextNote fromFile(std::string filename);
+private:
+	static constexpr const char* TEXT_FILE_EXTENSION = "txt";
+
+	static std::ofstream createFile(TextNote note, std::string path);
+	static void writeFile(std::ofstream& file, TextNote note);
+	static void writeTitle(std::ofstream& file, TextNote note);
+	static void writeCreationTime(std::ofstream& file, TextNote note);
+	static void writeText(std::ofstream& file, TextNote note);
+
+	static std::ifstream openFile(std::string path);
+	static TextNote initTextNote(std::ifstream& file);
+	static std::string readTitle(std::ifstream& file);
+	static std::time_t readCreationTime(std::ifstream& file);
+	static std::string readText(std::ifstream& file);
+
+
+
+
+
+};
+
+
+
+#endif /* SRC_CPP_FILEBUILDER_H_ */

--- a/src/cpp/FileBuilder.h
+++ b/src/cpp/FileBuilder.h
@@ -9,23 +9,15 @@
 #define FILEBUILDER_H_
 
 #include <fstream>
-
-#include "TextNote.h"
 #include "TextNoteCollection.h"
 #include <ctime>
 
-/*
- * File format is the following:
- * line 0: title
- * line 1: creation time (as time_t)
- * the rest is the text message of the note
- */
 
 class FileBuilder {
 public:
-	static bool toFile(TextNote* note, std::string path = "");
+	static void toFile(TextNote* note, std::string path = "");
 	static TextNote fromFile(std::string filename);
-	static bool toFile(TextNoteCollection* collection, std::string path = "");
+	static void toFile(TextNoteCollection* collection, std::string path = "");
 	static TextNoteCollection collectionFromFile(std::string filename);
 	static std::string toDateFormat(std::time_t time);
 	static std::time_t fromDateFormat(std::string str);
@@ -45,13 +37,11 @@ private:
 	static std::string readTitle(std::ifstream& file);
 	static std::time_t readCreationTime(std::ifstream& file);
 	static std::string readText(std::ifstream& file);
-	static int countBrackets(std::string str);
+
 	static void writeCollectionNotes(std::ofstream& file, TextNoteCollection* collection);
 	static void readCollectionNotes(std::ifstream& file, TextNoteCollection& collection);
 
-
-
-
+	static bool containsEndChar(std::string line);
 
 };
 

--- a/src/cpp/TextNote.cpp
+++ b/src/cpp/TextNote.cpp
@@ -15,6 +15,10 @@ TextNote::TextNote(std::string title, std::string text): _title{title}, _text{te
 
 }
 
+TextNote::TextNote(std::string title, std::string text, std::time_t creation_time):
+		_title(title), _text(text), _creation_time(creation_time){}
+
+
 std::string TextNote::title() const {
 	return _title;
 }
@@ -25,4 +29,11 @@ std::string TextNote::text() const {
 
 std::string TextNote::creation_time_string() const {
 	return std::asctime(std::localtime(&_creation_time));
+}
+std::time_t TextNote::creation_time() const {
+	return _creation_time;
+}
+
+void TextNote::print() const {
+	std::cout<<"title="<<title()<<", text="<<text()<<",created="<<creation_time_string()<<std::endl;
 }

--- a/src/cpp/TextNote.h
+++ b/src/cpp/TextNote.h
@@ -8,15 +8,19 @@
 #ifndef TEXTNOTE_H_
 #define TEXTNOTE_H_
 
-#include <string>
 #include <ctime>
-
+#include <string>
+#include <iostream>
 class TextNote {
+
 public:
 	TextNote(std::string title, std::string text = "");
+	TextNote(std::string title, std::string text, std::time_t creation_time);
 	std::string title() const;
 	std::string text() const;
 	std::string creation_time_string() const;
+	std::time_t creation_time() const;
+	void print() const;
 private:
 	std::string _title;
 	std::string _text;

--- a/src/cpp/TextNoteCollection.cpp
+++ b/src/cpp/TextNoteCollection.cpp
@@ -26,17 +26,18 @@ std::size_t TextNoteCollection::size() const {
 	return notes.size();
 }
 
-void TextNoteCollection::add(TextNote note)  {
+TextNoteCollection* TextNoteCollection::add(TextNote note)  {
 	notes.emplace_back(note);
+	return this;
 }
-TextNote TextNoteCollection::getNote(std::size_t num) const{
+TextNote TextNoteCollection::get(std::size_t num) const{
 	return notes[num];
 }
 std::string TextNoteCollection::creation_time_string() const{
 	return std::asctime(std::localtime(&_creation_time));
 }
 void TextNoteCollection::print() const{
-	std::cout << "Collection:\n"<<"title="<<_title<<",created="<<_creation_time<<"\n";
+	std::cout << "Collection:\n"<<"title="<<title()<<",created="<<creation_time_string()<<"\n";
 	for (std::size_t i = 0; i < notes.size();i++) {
 		notes[i].print();
 	}

--- a/src/cpp/TextNoteCollection.cpp
+++ b/src/cpp/TextNoteCollection.cpp
@@ -1,0 +1,29 @@
+/*
+ * TextNoteCollection.cpp
+ *
+ *  Created on: 10 Sep 2022
+ *      Author: MouseCreator
+ */
+
+#include "TextNoteCollection.h"
+
+TextNoteCollection::TextNoteCollection(std::string title, std::time_t creation_time):
+_title(title), _creation_time(creation_time){}
+
+TextNoteCollection::~TextNoteCollection() {
+
+}
+
+
+std::string TextNoteCollection::title() {
+	return _title;
+}
+std::time_t TextNoteCollection::creation_time() {
+	return _creation_time;
+}
+std::size_t TextNoteCollection::size() {
+	return notes.size();
+}
+TextNote TextNoteCollection::getNote(std::size_t num) {
+	return notes[num];
+}

--- a/src/cpp/TextNoteCollection.cpp
+++ b/src/cpp/TextNoteCollection.cpp
@@ -9,21 +9,35 @@
 
 TextNoteCollection::TextNoteCollection(std::string title, std::time_t creation_time):
 _title(title), _creation_time(creation_time){}
-
+TextNoteCollection::TextNoteCollection(std::string title):
+_title(title) { _creation_time = std::time(nullptr); }
 TextNoteCollection::~TextNoteCollection() {
 
 }
 
 
-std::string TextNoteCollection::title() {
+std::string TextNoteCollection::title() const{
 	return _title;
 }
-std::time_t TextNoteCollection::creation_time() {
+std::time_t TextNoteCollection::creation_time() const{
 	return _creation_time;
 }
-std::size_t TextNoteCollection::size() {
+std::size_t TextNoteCollection::size() const {
 	return notes.size();
 }
-TextNote TextNoteCollection::getNote(std::size_t num) {
+
+void TextNoteCollection::add(TextNote note)  {
+	notes.emplace_back(note);
+}
+TextNote TextNoteCollection::getNote(std::size_t num) const{
 	return notes[num];
+}
+std::string TextNoteCollection::creation_time_string() const{
+	return std::asctime(std::localtime(&_creation_time));
+}
+void TextNoteCollection::print() const{
+	std::cout << "Collection:\n"<<"title="<<_title<<",created="<<_creation_time<<"\n";
+	for (std::size_t i = 0; i < notes.size();i++) {
+		notes[i].print();
+	}
 }

--- a/src/cpp/TextNoteCollection.h
+++ b/src/cpp/TextNoteCollection.h
@@ -1,0 +1,30 @@
+/*
+ * TextNoteCollection.h
+ *
+ *  Created on: 10 Sep. 2022
+ *      Author: MouseCreator
+ */
+
+#ifndef TEXTNOTECOLLECTION_H_
+#define TEXTNOTECOLLECTION_H_
+#include <vector>
+#include "TextNote.h"
+class TextNoteCollection {
+public:
+	TextNoteCollection(std::string name, std::time_t creation_time);
+	virtual ~TextNoteCollection();
+
+	void addNote(TextNote note);
+	void removeNote(TextNote note);
+	TextNote getNote(std::size_t num);
+	std::string title();
+	std::time_t creation_time();
+	std::size_t size();
+private:
+	std::vector<TextNote> notes;
+
+	std::string _title;
+	std::time_t _creation_time;
+};
+
+#endif /* TEXTNOTECOLLECTION_H_ */

--- a/src/cpp/TextNoteCollection.h
+++ b/src/cpp/TextNoteCollection.h
@@ -15,9 +15,9 @@ public:
 	TextNoteCollection(std::string title, std::time_t creation_time);
 	virtual ~TextNoteCollection();
 
-	void add(TextNote note);
-	void remove(TextNote note);
-	TextNote getNote(std::size_t num) const;
+	TextNoteCollection* add(TextNote note);
+	//TODO: void remove();
+	TextNote get(std::size_t num) const;
 	std::string title() const;
 	std::time_t creation_time() const;
 	std::string creation_time_string() const;

--- a/src/cpp/TextNoteCollection.h
+++ b/src/cpp/TextNoteCollection.h
@@ -11,15 +11,18 @@
 #include "TextNote.h"
 class TextNoteCollection {
 public:
-	TextNoteCollection(std::string name, std::time_t creation_time);
+	TextNoteCollection(std::string title);
+	TextNoteCollection(std::string title, std::time_t creation_time);
 	virtual ~TextNoteCollection();
 
-	void addNote(TextNote note);
-	void removeNote(TextNote note);
-	TextNote getNote(std::size_t num);
-	std::string title();
-	std::time_t creation_time();
-	std::size_t size();
+	void add(TextNote note);
+	void remove(TextNote note);
+	TextNote getNote(std::size_t num) const;
+	std::string title() const;
+	std::time_t creation_time() const;
+	std::string creation_time_string() const;
+	std::size_t size() const;
+	void print() const;
 private:
 	std::vector<TextNote> notes;
 

--- a/src/cpp/main.cpp
+++ b/src/cpp/main.cpp
@@ -17,7 +17,7 @@ int main() {
 	// TextNote wrong(""); // FAILS: assertion failure (empty title)
 
 	TextNote note2("test1", "Listen to");
-	TextNote note3("test2", " the wind\n");
+	TextNote note3("test2", " the wind\n\n");
 	TextNote note4("test3", "of changes");
 	TextNoteCollection collection("test");
 	collection.add(note);

--- a/src/cpp/main.cpp
+++ b/src/cpp/main.cpp
@@ -6,16 +6,22 @@
  */
 
 #include "TextNote.h"
-
+#include "FileBuilder.h"
 #include <iostream>
 
 int main() {
 	std::cout<<"123"<<std::endl;
 	TextNote note("hello");
-	std::cout<<"title="<<note.title()<<", text="<<note.text()<<",created="<<note.creation_time_string()<<std::endl;
+	note.print();
 
 	// TextNote wrong(""); // FAILS: assertion failure (empty title)
 
+	TextNote note2("test", "some \n\n\tmessage\n\n");
+	FileBuilder::toFile(note2);
+
+	std::string path = FileBuilder::getFileName(note2.title());
+	TextNote note3 = FileBuilder::fromFile(path);
+	note3.print();
 	return 0;
 }
 

--- a/src/cpp/main.cpp
+++ b/src/cpp/main.cpp
@@ -16,12 +16,19 @@ int main() {
 
 	// TextNote wrong(""); // FAILS: assertion failure (empty title)
 
-	TextNote note2("test", "some \n\n\tmessage\n\n");
-	FileBuilder::toFile(&note2);
+	TextNote note2("test1", "Listen to");
+	TextNote note3("test2", " the wind\n");
+	TextNote note4("test3", "of changes");
+	TextNoteCollection collection("test");
+	collection.add(note);
+	collection.add(note2);
+	collection.add(note3);
+	collection.add(note4);
+	FileBuilder::toFile(&collection);
 
-	std::string path = FileBuilder::getFileName(note2.title());
-	TextNote note3 = FileBuilder::fromFile(path);
-	note3.print();
+
+	TextNoteCollection collection2 = FileBuilder::collectionFromFile("test");
+	collection2.print();
 	return 0;
 }
 

--- a/src/cpp/main.cpp
+++ b/src/cpp/main.cpp
@@ -19,11 +19,9 @@ int main() {
 	TextNote note2("test1", "Listen to");
 	TextNote note3("test2", " the wind\n\n");
 	TextNote note4("test3", "of changes");
+
 	TextNoteCollection collection("test");
-	collection.add(note);
-	collection.add(note2);
-	collection.add(note3);
-	collection.add(note4);
+	collection.add(note)->add(note2)->add(note3)->add(note4);
 	FileBuilder::toFile(&collection);
 
 

--- a/src/cpp/main.cpp
+++ b/src/cpp/main.cpp
@@ -17,7 +17,7 @@ int main() {
 	// TextNote wrong(""); // FAILS: assertion failure (empty title)
 
 	TextNote note2("test", "some \n\n\tmessage\n\n");
-	FileBuilder::toFile(note2);
+	FileBuilder::toFile(&note2);
 
 	std::string path = FileBuilder::getFileName(note2.title());
 	TextNote note3 = FileBuilder::fromFile(path);


### PR DESCRIPTION
Methods from FileBuilder might be moved to the TextNote and TextNoteCollection classes. However, in my opinion, it will end up being too much work for those classes (storing information + turning it into a text file + something in the future).

FileBuilder contains several useful methods, which convert YYYY.MM.DD HH:MM:SS dates from string to time_t and backwards.

The significant change since the last pull request is that FileBuilder now works with pointers, which means TextNote is not copied to the function.

I used special char (_ENDCHAR = '-3'_) in order to split several notes from a collection. Looking for better way of doing this.