### PR TITLE
Reading only current_collection value from config.txt

### DIFF
--- a/src/cpp/CommandLineProcessor.cpp
+++ b/src/cpp/CommandLineProcessor.cpp
@@ -1,8 +1,10 @@
 #include "CommandLineProcessor.h"
 #include "CommandLineProcessorConstants.h"
+#include "Config.h"
 #include "FileBuilder.h"
 #include "TextNote.h"
 #include "TextNoteCollection.h"
+#include <iostream>
 
 #include "doctest.h"
 
@@ -30,12 +32,19 @@ void CommandLineProcessor::addNote(const std::string &title) {
     }
     TextNote newTextNote(title, text);
 
+    // Loading current collection name from config
+    Config config;
+    config.read_from_file(CONFIG_FILE_PATH_NAME);
+
+    // CONFIG MUST RETURN FILE PATH NOT NAME
+    std::string currentCollectionPath = config.get(COLLECTION_KEY);
+
     // Saving the text note to current collection
-    TextNoteCollection currentCollection = FileBuilder::collectionFromFile(READ_FILE_NAME);
+    TextNoteCollection currentCollection = FileBuilder::collectionFromFile(currentCollectionPath);
     currentCollection.add(newTextNote);
 
     // Saving current collection back to file
-    FileBuilder::toFile(&currentCollection, SAVE_FILE_PATH_NAME);
+    FileBuilder::toFile(&currentCollection, currentCollectionPath);
 }
 
 //TEST_CASE("imitate CLI call - add note") {

--- a/src/cpp/CommandLineProcessor.h
+++ b/src/cpp/CommandLineProcessor.h
@@ -3,7 +3,6 @@
 
 #include <string>
 
-
 class CommandLineProcessor {
 private:
     static void addNote(const std::string &title);

--- a/src/cpp/CommandLineProcessorConstants.h
+++ b/src/cpp/CommandLineProcessorConstants.h
@@ -3,7 +3,7 @@
 
 const char* ADD_NOTE_NAME = "add";
 
-const char* READ_FILE_NAME = "config.txt";
-const char* SAVE_FILE_PATH_NAME = "../../resources/config.txt";
+const char* COLLECTION_KEY = "current_collection";
+const char* CONFIG_FILE_PATH_NAME = "../../resources/config.txt";
 
 #endif //KNOWYOURKNOWLEDGE_COMMANDLINEPROCESSORCONSTANTS_H


### PR DESCRIPTION
CommandLineProcessor::addNote now reads only file path name from config.txt. Please, note that Config::get must return a FILE PATH name, not just a collection name.